### PR TITLE
chore: Denormalize ray direction

### DIFF
--- a/experiments/rtow/shape.go
+++ b/experiments/rtow/shape.go
@@ -46,7 +46,7 @@ type Sphere struct {
 func (s *Sphere) Hit(r *geo.Ray, tMin, tMax float64) (*Hit, bool) {
 	L := r.Origin.Minus(s.Center)
 
-	a := 1.0 // a = ||r.Dir||^2 == 1
+	a := r.Dir.Dot(r.Dir)
 	b := 2 * L.Dot(geo.Vec(r.Dir))
 	c := L.Dot(L) - s.Radius*s.Radius
 
@@ -68,7 +68,8 @@ func (s *Sphere) Hit(r *geo.Ray, tMin, tMax float64) (*Hit, bool) {
 	norm, _ := point.Minus(s.Center).Unit()
 
 	// Determine if ray is coming from inside the sphere
-	interior := r.Dir.Enters(norm)
+	unitDir, _ := r.Dir.Unit()
+	interior := unitDir.Enters(norm)
 	// If it is, we need to flip the normal its towards the center of the sphere
 	if interior {
 		norm = norm.Reverse()

--- a/pkg/camera/perspective.go
+++ b/pkg/camera/perspective.go
@@ -82,7 +82,7 @@ func (c *Perspective) Ray(u, v float64) *geo.Ray {
 	// ...and the direction is given by (p-camera_origin) == p-{0, 0, 0} == p
 	//
 	// All that remains is to convert that direction to world space.
-	dir, _ := c.camToWorld.MultVec(p).Unit()
+	dir := c.camToWorld.MultVec(p)
 
 	return geo.NewRay(c.eye, dir)
 }

--- a/pkg/geo/ray.go
+++ b/pkg/geo/ray.go
@@ -2,8 +2,7 @@ package geo
 
 // Ray is a geometric ray.
 type Ray struct {
-	Origin Vec
-	Dir    Unit
+	Origin, Dir Vec
 }
 
 // NewRay is a convenience constructor for the Ray struct. Mostly because
@@ -13,7 +12,10 @@ type Ray struct {
 // is much more tedious than
 //
 //	r := NewRay(origin, dir)
-func NewRay(origin Vec, dir Unit) *Ray {
+func NewRay(origin, dir Vec) *Ray {
+	if (dir == Vec{}) {
+		panic("Cannot create Ray with 0-direction")
+	}
 	return &Ray{origin, dir}
 }
 

--- a/pkg/geo/transform_test.go
+++ b/pkg/geo/transform_test.go
@@ -26,10 +26,10 @@ func TestLookAt(t *testing.T) {
 	target := Origin
 	m := LookAt(eye, target, YAxis)
 
-	r := NewRay(Origin, Unit{0, 0, -1})
+	r := NewRay(Origin, Vec{0, 0, -1})
 
 	assert.Equal(t, eye, m.MultPoint(r.Origin))
 
 	c := 1.0 / math.Sqrt(3.0)
-	assertVecEqual(t, Vec{-c, -c, -c}, m.MultUnit(r.Dir), 0.00001)
+	assertVecEqual(t, Vec{-c, -c, -c}, m.MultVec(r.Dir), 0.00001)
 }

--- a/pkg/primitive/sphere.go
+++ b/pkg/primitive/sphere.go
@@ -16,7 +16,7 @@ type Sphere struct {
 func (s *Sphere) Intersect(ray *geo.Ray) float64 {
 	L := ray.Origin.Minus(s.Center)
 
-	a := 1.0 // a = ||ray.Dir||^2 == 1
+	a := ray.Dir.Dot(ray.Dir)
 	b := 2 * L.Dot(geo.Vec(ray.Dir))
 	c := L.Dot(L) - s.Radius*s.Radius
 


### PR DESCRIPTION
Reduces overhead in intersection and camera code, plus allows t-parameter preservation across object-to-world and world-to-object transformations